### PR TITLE
Remove Won / Lost boolean for Cases

### DIFF
--- a/content/cases/ab-v-ontario-education.md
+++ b/content/cases/ab-v-ontario-education.md
@@ -9,7 +9,6 @@ description: Application about the respondent’s repeal of the 2015 sex educati
 takeaway: This case affirmed that teachers must include LGBTQ+ students in their
   sexual education curriculum because the Human Rights Code and the Canadian
   Charter of Rights and Freedoms requires them to.
-hasWon: false
 url: https://www.canlii.org/en/on/onhrt/doc/2019/2019hrto685/2019hrto685.html
 themes:
   - Employment

--- a/content/cases/b-v-a.md
+++ b/content/cases/b-v-a.md
@@ -8,7 +8,6 @@ takeaway: Historically, surgery was required in order for transgender folks to
   identify as their true gender. In this case, the transgender female applicant
   did not have gender affirming surgery and therefore was recognized as a man
   under the law.
-hasWon: false
 url: https://www.canlii.org/en/on/onsc/doc/1990/1990canlii7012/1990canlii7012.html?autocompleteStr=b%20v%20a%201990&autocompletePos=1
 themes:
   - Identification

--- a/content/cases/c-l-v-c-c.md
+++ b/content/cases/c-l-v-c-c.md
@@ -11,7 +11,6 @@ takeaway: One of the applicant's in this case had not undergone gender affirming
   as a result, both of the applicants were viewed as women. The marriage was
   nulled because same sex marriage was not legalized (and would continute to be
   illegal until 2005).
-hasWon: false
 url: https://www.canlii.org/en/on/onsc/doc/1992/1992canlii7651/1992canlii7651.html?autocompleteStr=c(l)%20v%20C&autocompletePos=1
 themes:
   - Marriage

--- a/content/cases/en-v-gallagher’s-bar-and-lounge.md
+++ b/content/cases/en-v-gallagher’s-bar-and-lounge.md
@@ -8,7 +8,6 @@ description: Applicants (employees of Gallagher's) allege that they asked JG to
 takeaway: This case, like many others, shows that consistently misusing gender
   pronouns and using slurs, even behind someone's back, is a direct violation of
   the Human Rights Code.
-hasWon: true
 url: https://www.canlii.org/en/on/onhrt/doc/2021/2021hrto240/2021hrto240.html?searchUrlHash=AAAAAQBPImdlbmRlciBleHByZXNzaW9uIiwgImdlbmRlciBpZGVudGl0eSIsICJnZW5kZXIiLCAiZGlzY3JpbWluYXRpb24iLCB0cmFuc2dlbmRlcgAAAAAB&resultIndex=9
 themes:
   - Employment

--- a/content/cases/forrester-v-saliba.md
+++ b/content/cases/forrester-v-saliba.md
@@ -11,7 +11,6 @@ description: Respondent askes the court to change the order of December 10, 1996
   custodial arrangement
 takeaway: "This case is important because it proves that a parent's gender
   transition does not necessarily impact their ability to effectively parent. "
-hasWon: false
 url: https://www.canlii.org/en/on/oncj/doc/2000/2000canlii28722/2000canlii28722.html?autocompleteStr=forrester%20v%20&autocompletePos=4
 themes:
   - Marriage

--- a/content/cases/re-reid.md
+++ b/content/cases/re-reid.md
@@ -6,7 +6,6 @@ description: Application by a 32 y/o unmarried man for a name change
 takeaway: In this case, the applicant was planning on having gender affirming
   surgery and therefore was allowed to have a legal name change. Surgery was
   required for gender affirmation practices until 2014.
-hasWon: true
 url: https://www.canlii.org/en/on/onsc/doc/1986/1986canlii2821/1986canlii2821.html?autocompleteStr=RE%20REID%201986&autocompletePos=1
 themes:
   - Name Change

--- a/content/cases/salsman-v-london-sales-arena-corp.md
+++ b/content/cases/salsman-v-london-sales-arena-corp.md
@@ -4,13 +4,12 @@ caseName: Salsman v London Sales Arena Corp.
 citation: 2014 HRTO 775
 description: >-
   "Three transgender complainants were staffing Clarke-McIlwain’s Candy booth at
-  the market Trails end owned by London Sales Arena Corp.  
+  the market Trails end owned by London Sales Arena Corp.
 
 
   Rent collector/Manager and the Owner of the market were displeased with these three tending the booth. The reasons for this displeasure is disputed.  Respondents allege that it was because the applicants lit incense at the booth and were scantily and inappropriately dressed. Applicants allege that it was because they are transgendered. After the incident, Mr. Kikkert (owner) went on a radio show and talked about the market being a “family market”; the fact that he did not have washroom facilities for “these people”; and he referred to the applicants as “people like that”"
 takeaway: It affirms that transgender folks ought to have full access to their
   desired public washroom, whether or not they have undergone surgery.
-hasWon: true
 url: https://www.canlii.org/en/on/onhrt/doc/2014/2014hrto775/2014hrto775.html?resultIndex=1
 themes:
   - Employment

--- a/content/cases/xy-v-ontario-government-and-consumer-services.md
+++ b/content/cases/xy-v-ontario-government-and-consumer-services.md
@@ -10,7 +10,6 @@ description: Transgender woman challenged the Government of Ontario's
   transgender folks to undergo surgery to have their sex designation on their
   identification match their gender identity.
 takeaway: "It affirms the importance of self-identifying gender for legal purposes. "
-hasWon: true
 url: https://www.canlii.org/en/on/onhrt/doc/2012/2012hrto726/2012hrto726.html?resultIndex=1
 themes:
   - Identification

--- a/content/pages/cases.md
+++ b/content/pages/cases.md
@@ -6,6 +6,6 @@ hero:
   image:
     imageFile: /assets/gegi_law-400x386.png
     alt: Gegi Law
-wonIcon: /assets/case.png
-lostIcon: /assets/case-white.png
+cornerstoneIcon: /assets/case.png
+caseIcon: /assets/case-white.png
 ---

--- a/src/components/CaseCard.js
+++ b/src/components/CaseCard.js
@@ -9,11 +9,11 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 export default function CaseCard({ cas, icon }) {
   const {
+    isCornerstone,
     caseName,
     citation,
     description,
     takeaway,
-    hasWon,
     url,
     themes,
   } = cas
@@ -24,10 +24,10 @@ export default function CaseCard({ cas, icon }) {
         <div className="card-pre">
           <GatsbyImage
             image={icon.childImageSharp.gatsbyImageData}
-            alt={hasWon ? 'Case Won Icon' : 'Case Lost Icon'}
+            alt={isCornerstone ? 'Cornerstone Case Icon' : 'Case Icon'}
             imgStyle={{ width: `auto` }}
           />
-          <p style={{ color: `var(--grey)` }}>{citation} · {hasWon ? 'Won' : 'Lost'}</p>
+          <p style={{ color: `var(--grey)` }}>{citation}{isCornerstone ? ' · Cornerstone Case' : ''}</p>
         </div>
         <h3>
           <span style={{ marginRight: `0.5rem` }}>{caseName}</span>

--- a/src/components/CaseCard.js
+++ b/src/components/CaseCard.js
@@ -30,7 +30,7 @@ export default function CaseCard({ cas, icon }) {
           <p style={{ color: `var(--grey)` }}>{citation}{isCornerstone ? ' · Cornerstone Case' : ''}</p>
         </div>
         <h3>
-          <span style={{ marginRight: `0.5rem` }}>{caseName}</span>
+          <a href={url} target='_blank' rel="noreferrer" style={{ marginRight: `0.5rem` }}>{caseName}</a>
           <Tooltip title="Open in Canlii" placement="right">
             <IconButton href={url} target='_blank' rel="noreferrer">
               <OpenInNewIcon fontSize='default' />

--- a/src/components/CaseCards.js
+++ b/src/components/CaseCards.js
@@ -2,14 +2,14 @@ import * as React from "react"
 import styled from "styled-components"
 import CaseCard from './CaseCard'
 
-export default function CaseCards({ cases, wonIcon, lostIcon }) {
+export default function CaseCards({ cases, cornerstoneIcon, caseIcon }) {
   return (
     <CaseCardsStyles>
       {cases.map(cas => (
         <CaseCard
           key={cas.caseName + `Card`}
           cas={cas}
-          icon={cas.hasWon ? wonIcon : lostIcon} />
+          icon={cas.isCornerstone ? cornerstoneIcon : caseIcon} />
       ))}
     </CaseCardsStyles>
   )

--- a/src/pages/cases.js
+++ b/src/pages/cases.js
@@ -11,7 +11,7 @@ import SiteBorderStyles from "../styles/SiteBorderStyles"
 
 
 export default function CasesPage({ data: { page, collections } }) {
-  const { title, hero, wonIcon, lostIcon  } = page.childMarkdownRemark.frontmatter
+  const { title, hero, cornerstoneIcon, caseIcon  } = page.childMarkdownRemark.frontmatter
 
   // build themes (filter)
   const themes = collections.group
@@ -38,7 +38,7 @@ export default function CasesPage({ data: { page, collections } }) {
         <SiteBorderStyles>
           <CaseContentStyles>
             <Themes allCases={allCases} setCases={setCases} themes={themes}  />
-            <CaseCards cases={cases} wonIcon={wonIcon} lostIcon={lostIcon} />
+            <CaseCards cases={cases} cornerstoneIcon={cornerstoneIcon} caseIcon={caseIcon} />
           </CaseContentStyles>
         </SiteBorderStyles>
       </section>
@@ -86,7 +86,7 @@ export const data = graphql`
               }
             }
           }
-          wonIcon {
+          cornerstoneIcon {
             childImageSharp {
               gatsbyImageData(
                 width: 50
@@ -95,7 +95,7 @@ export const data = graphql`
               )
             }
           }
-          lostIcon {
+          caseIcon {
             childImageSharp {
               gatsbyImageData(
                 width: 50
@@ -113,12 +113,12 @@ export const data = graphql`
         nodes {
           childMarkdownRemark {
             frontmatter {
+              isCornerstone
               category
               caseName
               citation
               description
               takeaway
-              hasWon
               url
               themes
             }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -76,7 +76,6 @@ collections:
       - {label: Citation, name: citation, widget: string, required: true}
       - {label: Description, name: description, widget: text, required: true}
       - {label: Takeaway, name: takeaway, widget: text, required: false}
-      - {label: "Has won?", name: hasWon, widget: boolean, default: false}
       - {label: Link, name: url, widget: string, required: true}
       - label: Themes
         name: themes
@@ -209,8 +208,8 @@ collections:
               - {label: Heading, name: heading, widget: string}
               - {label: Description, name: description, widget: text}
               - {label: Image, name: image, widget: object, fields: [{label: Image File, name: imageFile, widget: image}, {label: Alt, name: alt, widget: string}]}
-          - {label: Won Icon, name: wonIcon, widget: image}
-          - {label: Lost Icon, name: lostIcon, widget: image}
+          - {label: Cornerstone Case Icon, name: cornerstoneIcon, widget: image}
+          - {label: Non-Cornerstone Case Icon, name: caseIcon, widget: image}
 
   - label: Settings
     name: settings


### PR DESCRIPTION
- Use `isCornerstone` Case in place of `hasWon` for the icon display
- Make all case title clickable and link to Canlii case page

![Screenshot from 2021-07-01 09-44-22](https://user-images.githubusercontent.com/59268689/124134596-fce46f00-da50-11eb-8c76-d1d9cebd2ec3.png)
